### PR TITLE
fix: ダミーデータの作成件数を2⇨10に変更

### DIFF
--- a/api/tests/factories/user.py
+++ b/api/tests/factories/user.py
@@ -5,13 +5,12 @@ faker = Faker(['en_US'])
 
 
 class UserFactory(factory.django.DjangoModelFactory):
-
     class Meta:
         model = 'api.User'
         django_get_or_create = ('username', 'email', 'password')
 
     username = faker.name()
-    email = faker.email()
+    email = factory.Sequence(lambda n: "{0}{1}".format(n, faker.email()))
     password = faker.password
 
 

--- a/population.py
+++ b/population.py
@@ -1,7 +1,8 @@
 import os
+import django
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'friends_phrase.settings')
 
-import django
 django.setup()
 from api.tests.factories.language import LanguageFactory
 from api.tests.factories.user import UserFactory
@@ -10,17 +11,17 @@ from api.tests.factories.phrase import PhraseFactoryWith
 from api.tests.factories.comment import CommentFactoryWith
 
 
-def populate(n=2):
+def populate(n=10):
     for _ in range(n):
         language = LanguageFactory()
-        phrase_user = UserFactory(username='factory_user1', email='factory1@sample.com')
+        phrase_user = UserFactory()
         ProfileFactoryWith(user=phrase_user)
-        phrase = PhraseFactoryWith(user=phrase_user,
-                                   text_language=language,
-                                   translated_word_language=language)
-        comment_user = UserFactory(username='factory_user2', email='factory2@sample.com')
+        phrases = PhraseFactoryWith.create_batch(n, user=phrase_user,
+                                                 text_language=language,
+                                                 translated_word_language=language)
+        comment_user = UserFactory()
         language = LanguageFactory()
-        CommentFactoryWith(user=comment_user, phrase=phrase, text_language=language)
+        CommentFactoryWith(user=comment_user, phrase=phrases[0], text_language=language)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

-  `python population.py`コマンドによる、ダミーデータの作成件数を2件から10件に変更
- UserモデルのFactoryを作成する際に、ベタ書きだったのをSequenceとfackerを用いた修正

## 注意点

`PEP 8: E402 module level import not at top of file`
上記の警告が出ていますが、各モデルのFactoryをimportする前に`os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'friends_phrase.settings')
`を実行する必要があるため、一旦無視しています。


## チェックリスト
- [x] testが全てパスしていること
