### PR TITLE
fix: ログインユーザーの情報を名前のみ渡す使用に変更

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -18,6 +18,15 @@ class UserSerializer(serializers.ModelSerializer):
         return get_user_model().objects.create_user(**validated_data)
 
 
+class LoginUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields = ['username']
+        extra_kwargs = {
+            'username': {'required': True},
+        }
+
+
 class ProfileSerializer(serializers.ModelSerializer):
     username = serializers.ReadOnlyField(source='user.username')
 

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -29,7 +29,6 @@ class AuthorizedUserApiTest(TestCase):
         res = self.client.get(LOGIN_USER_URL)
 
         self.assertEqual(res.data['username'], self.user.username)
-        self.assertEqual(res.data['email'], self.user.email)
 
     def test_should_partial_update_user(self):
         payload = {'username': 'update_username', 'email': 'update_username@sample.com', 'password': 'dummy_pw'}

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,7 +11,7 @@ router.register('comment', views.CommentViewSet)
 app_name = 'api'
 
 urlpatterns = [
-    path('login_user/', views.RetrieveLonginUserView.as_view(), name='login_user'),
+    path('login_user/', views.RetrieveLoginUserView.as_view(), name='login_user'),
     path('user/', views.CreateUserView.as_view(), name='create_user'),
     path('user/<uuid:pk>/', views.RetrieveUpdateDestroyUserView.as_view(), name='user'),
     path('', include(router.urls)),

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,9 @@
 from rest_framework import generics, permissions, viewsets
-from .serializers import UserSerializer, ProfileSerializer, PhraseSerializer, CommentSerializer
+from .serializers import UserSerializer, \
+    ProfileSerializer, \
+    PhraseSerializer, \
+    CommentSerializer, \
+    LoginUserSerializer
 from .models import User, Profile, Phrase, Comment
 from .permissions import IsOwnerOrReadOnly
 
@@ -9,8 +13,8 @@ class CreateUserView(generics.CreateAPIView):
     permission_classes = (permissions.AllowAny,)
 
 
-class RetrieveLonginUserView(generics.RetrieveAPIView):
-    serializer_class = UserSerializer
+class RetrieveLoginUserView(generics.RetrieveAPIView):
+    serializer_class = LoginUserSerializer
 
     def get_object(self):
         return self.request.user


### PR DESCRIPTION
## 概要

- /api/login_user/にリクエストがあった際にレスポンスの値をusernameのみに変更(idやcreatedAtなどはまだ使用していないため)

## チェックリスト
- [x] pycharmが警告やエラーを出さないこと
- [x] testが全てパスしていること