### PR TITLE
fix: ダミーのフレーズの翻訳を英語から日本語に変更

### DIFF
--- a/api/tests/factories/phrase.py
+++ b/api/tests/factories/phrase.py
@@ -3,7 +3,8 @@ import factory
 from faker import Faker
 from .user import UserFactory, TestUserFactory
 
-faker = Faker(['en_US'])
+en_faker = Faker(['en_US'])
+jp_faker = Faker(['jp_JP'])
 
 
 class PhraseFactoryWith(factory.django.DjangoModelFactory):
@@ -17,9 +18,9 @@ class PhraseFactoryWith(factory.django.DjangoModelFactory):
     user = factory.SubFactory(
         UserFactory,
     )
-    text = faker.sentence(nb_words=8)
+    text = en_faker.sentence(nb_words=8)
     text_language = 'en'
-    translated_word = faker.sentence(nb_words=8),
+    translated_word = jp_faker.sentence(nb_words=8),
     translated_word_language = 'jp'
 
 


### PR DESCRIPTION
## 概要

- fakerを使用したダミーデータの作成の際に、translated_wordプロパティーに英語で作ってしまっていた英語のダミーデータを日本語に変更

## スクリーンショット
<img width="377" alt="スクリーンショット 2022-06-04 11 06 17" src="https://user-images.githubusercontent.com/46844364/171972524-af01c8d9-c497-41b4-99d5-e50ed2870b85.png">


## チェックリスト
- [x] pycharmが警告やエラーを出さないこと
- [x] testが全てパスしていること