### PR TITLE
fix: フレーズにコメントIDを返すパラメーターを追加

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -130,7 +130,7 @@ class Comment(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE
     )
-    phrase = models.ForeignKey(Phrase, on_delete=models.CASCADE)
+    phrase = models.ForeignKey(Phrase, on_delete=models.CASCADE, related_name='comments')
     text_language = models.CharField(max_length=8)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -58,6 +58,7 @@ class PhraseSerializer(serializers.ModelSerializer):
                   'created_at',
                   'updated_at',
                   'username',
+                  'comments',
                   ]
 
         extra_kwargs = {
@@ -65,6 +66,7 @@ class PhraseSerializer(serializers.ModelSerializer):
             'text_language': {'required': True},
             'translated_word': {'required': True},
             'translated_word_language': {'required': True},
+            'comments': {'read_only': True}
         }
 
 

--- a/api/tests/test_comment.py
+++ b/api/tests/test_comment.py
@@ -44,6 +44,7 @@ class CommentApiTest(APITestCase):
         self.assertEqual(comment.user.username, self.user.username)
         self.assertEqual(comment.created_at, DT)
         self.assertEqual(comment.updated_at, DT)
+        self.assertEqual(self.test_phrase.comments.count(), 1)
 
     def test_should_not_create_comment_with_blank_value(self):
         payload = {

--- a/api/tests/test_phrase.py
+++ b/api/tests/test_phrase.py
@@ -8,6 +8,7 @@ from .factories.user import TestUserFactory, UserFactory
 from api.models import Phrase
 from django.contrib.auth import get_user_model
 from freezegun import freeze_time
+from api.serializers import PhraseSerializer
 
 DT = datetime(2022, 2, 22, 2, 22)
 UPDATE_DT = datetime(2022, 3, 22, 2, 22)
@@ -45,6 +46,7 @@ class PhraseApiTest(APITestCase):
         self.assertEqual(phrase.created_at, DT)
         self.assertEqual(phrase.updated_at, DT)
         self.assertEqual(phrase.user, self.user)
+        self.assertEqual(phrase.comments.count(), 0)
 
 
 def test_should_not_create_phrase_by_blank_value(self):
@@ -99,6 +101,7 @@ def test_should_update_phrase(self):
     self.assertEqual(phrase.created_at, DT)
     self.assertEqual(phrase.updated_at, UPDATE_DT)
     self.assertEqual(phrase.user, self.user)
+    self.assertEqual(phrase.comments.count(), 0)
 
 
 def test_should_not_update_phrase_with_not_owner(self):
@@ -191,6 +194,7 @@ def test_should_partial_update_phrase(self):
     self.assertEqual(phrase.created_at, DT)
     self.assertEqual(phrase.updated_at, UPDATE_DT)
     self.assertEqual(phrase.user, self.user)
+    self.assertEqual(phrase.comments.count(), 0)
 
 
 def test_should_not_partial_update_phrase_with_not_owner(self):


### PR DESCRIPTION
## 概要

- Phraseのapiにアクセスがあった際にコメントのID一覧を返すパラメーターを追加
- 上記のテストの追加

## チェックリスト
- [x] pycharmが警告やエラーを出さないこと
- [x] testが全てパスしていること