### PR TITLE
fix: 渡すログインユーザーの情報にusernameを追加

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -6,8 +6,9 @@ from django.contrib.auth import get_user_model
 class LoginUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = ['icon']
+        fields = ['username', 'icon']
         extra_kwargs = {
+            'username': {'read_only': True},
             'icon': {'read_only': True}
         }
 

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -28,7 +28,7 @@ class AuthorizedUserApiTest(TestCase):
     def test_should_return_login_user_icon(self):
         res = self.client.get(LOGIN_USER_URL)
 
-        self.assertEqual(list(res.data.keys()), ['icon'])
+        self.assertEqual(list(res.data.keys()), ['username', 'icon'])
         self.assertEqual(res.data['icon'], 'http://testserver/media/icons/default.png')
 
     def test_should_partial_update_user(self):


### PR DESCRIPTION
## 概要

- /api/login_user/にリクエストがあった際に、iconパラメーターのみ渡していたのを、usernameも追加

## チェックリスト
- [x] pycharmが警告やエラーを出さないこと
- [x] testが全てパスしていること