### PR TITLE
fix: CORS_ORIGIN_WHITELISTを環境変数で管理に変更

### DIFF
--- a/friends_phrase/settings.py
+++ b/friends_phrase/settings.py
@@ -60,9 +60,10 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'friends_phrase.urls'
 
-CORS_ORIGIN_WHITELIST = [
-    "http://localhost:3000"
-]
+CORS_ORIGIN_WHITELIST = env.list('CORS_ORIGIN_WHITELIST')
+#     [
+#     "http://localhost:3000"
+# ]
 
 SIMPLE_JWT = {
     'AUTH_HEADER_TYPES': ('JWT',),


### PR DESCRIPTION
## 概要

- CORS_ORIGIN_WHITELISTを.envに追加

## チェックリスト
- [x] pycharmが警告やエラーを出さないこと
- [x] testが全てパスしていること